### PR TITLE
support for multiple enforce group id associate to aws account

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ module "chainguard-account-association" {
   source = "chainguard-dev/chainguard-account-association/aws"
 
   enforce_group_id  = "<< enforce group id >>"
-  enforce_group_ids = ["<< enforce group id 1 >>", "<< enforce group id 2 >>"] # Optional, used only when more than one group
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Or using our (soon to be released publically) Terraform provider
 
 ```Terraform
 resource "chainguard_account_associations" "example" {
-  group = "<< enforce group id>>"
+  group = ["<< enforce group id >>"]
   amazon {
-    account = "<< 12 digit account id>>"
-  }
+    account = "<< 12 digit account id >>"
+  } 
 }
 ```
 
@@ -41,7 +41,7 @@ To configured the connection on AWS side use this module as follows:
 module "chainguard-account-association" {
   source = "chainguard-dev/chainguard-account-association/aws"
 
-  enforce_group_id = "<< enforce group id>>"
+  enforce_group_ids = ["<< enforce group id >>"]
 }
 ```
 
@@ -103,7 +103,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_enforce_domain_name"></a> [enforce\_domain\_name](#input\_enforce\_domain\_name) | Domain name of your Chainguard Enforce environment | `string` | `"enforce.dev"` | no |
-| <a name="input_enforce_group_id"></a> [enforce\_group\_id](#input\_enforce\_group\_id) | Enforce IAM group ID to bind your AWS account to | `string` | n/a | yes |
+| <a name="input_enforce_group_ids"></a> [enforce\_group\_ids](#input\_enforce\_group\_ids) | Enforce IAM group IDs to bind your AWS account to | `list(string)` | n/a | yes |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ resource "chainguard_account_associations" "example" {
   group = "<< enforce group id >>"
   amazon {
     account = "<< 12 digit account id >>"
-  } 
+  }
 }
 ```
 
@@ -73,7 +73,8 @@ below the scope of the Enforce group you configure.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.7.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.39.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | n/a |
 
 ## Modules
 
@@ -97,6 +98,7 @@ No modules.
 | [aws_iam_role_policy_attachment.cosigned_kms_pki_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.discovery_cluster_viewer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.enforce_signer_kms_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [null_resource.enforce_group_id_is_specified](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ below the scope of the Enforce group you configure.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.39.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.7.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | n/a |
 
 ## Modules

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ To configured the connection on AWS side use this module as follows:
 module "chainguard-account-association" {
   source = "chainguard-dev/chainguard-account-association/aws"
 
-  enforce_group_ids = ["<< enforce group id >>"]
+  enforce_group_id  = "<< enforce group id >>"
+  enforce_group_ids = ["<< enforce group id 1 >>", "<< enforce group id 2 >>"] # Optional, used only when more than one group
 }
 ```
 
@@ -72,7 +73,7 @@ below the scope of the Enforce group you configure.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.39.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ module "chainguard-account-association" {
   source = "chainguard-dev/chainguard-account-association/aws"
 
   enforce_group_id  = "<< enforce group id >>"
+  enforce_group_ids = ["<< enforce group id 1 >>", "<< enforce group id 2 >>"] # Optional, used only when more than one group
 }
 ```
 
@@ -72,7 +73,7 @@ below the scope of the Enforce group you configure.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.7.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ below the scope of the Enforce group you configure.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.7.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.39.0 |
 
 ## Modules
 
@@ -103,7 +103,8 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_enforce_domain_name"></a> [enforce\_domain\_name](#input\_enforce\_domain\_name) | Domain name of your Chainguard Enforce environment | `string` | `"enforce.dev"` | no |
-| <a name="input_enforce_group_ids"></a> [enforce\_group\_ids](#input\_enforce\_group\_ids) | Enforce IAM group IDs to bind your AWS account to | `list(string)` | n/a | yes |
+| <a name="input_enforce_group_id"></a> [enforce\_group\_id](#input\_enforce\_group\_id) | DEPRECATED: Please use 'enforce\_group\_ids'. Enforce IAM group ID to bind your AWS account to | `string` | n/a | yes |
+| <a name="input_enforce_group_ids"></a> [enforce\_group\_ids](#input\_enforce\_group\_ids) | Enforce IAM group IDs to bind your AWS account to. If both 'enforce\_group\_id' and 'enforce\_group\_ids' are specified, 'enforce\_group\_id' is ignored. | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or using our (soon to be released publically) Terraform provider
 
 ```Terraform
 resource "chainguard_account_associations" "example" {
-  group = ["<< enforce group id >>"]
+  group = "<< enforce group id >>"
   amazon {
     account = "<< 12 digit account id >>"
   } 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_enforce_domain_name"></a> [enforce\_domain\_name](#input\_enforce\_domain\_name) | Domain name of your Chainguard Enforce environment | `string` | `"enforce.dev"` | no |
-| <a name="input_enforce_group_id"></a> [enforce\_group\_id](#input\_enforce\_group\_id) | DEPRECATED: Please use 'enforce\_group\_ids'. Enforce IAM group ID to bind your AWS account to | `string` | n/a | yes |
+| <a name="input_enforce_group_id"></a> [enforce\_group\_id](#input\_enforce\_group\_id) | DEPRECATED: Please use 'enforce\_group\_ids'. Enforce IAM group ID to bind your AWS account to | `string` | `""` | no |
 | <a name="input_enforce_group_ids"></a> [enforce\_group\_ids](#input\_enforce\_group\_ids) | Enforce IAM group IDs to bind your AWS account to. If both 'enforce\_group\_id' and 'enforce\_group\_ids' are specified, 'enforce\_group\_id' is ignored. | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/agentless.tf
+++ b/agentless.tf
@@ -5,6 +5,8 @@
 //        --arn arn:aws:iam::${TF_VAR_ACCOUNT_ID}:role/chainguard-agentless \
 //        --group system:masters --username admin
 resource "aws_iam_role" "agentless_role" {
+  for_each = toset(var.enforce_group_ids)
+
   name = "chainguard-agentless"
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",
@@ -20,7 +22,7 @@ resource "aws_iam_role" "agentless_role" {
           // components, which mints tokens suitable for talking to EKS
           // clusters.  We are authorizing components nested under GROUP
           // to perform this impersonation.
-          "issuer.${var.enforce_domain_name}:sub" : "agentless:${var.enforce_group_id}"
+          "issuer.${var.enforce_domain_name}:sub" : "agentless:${each.value}"
           // Tokens must be intended for use with Amazon.
           "issuer.${var.enforce_domain_name}:aud" : "amazon"
         }
@@ -57,6 +59,8 @@ resource "aws_iam_policy" "eks_read_policy" {
 
 // The permissions to grant the "agentless" role.
 resource "aws_iam_role_policy_attachment" "agentless_eks_read" {
-  role       = aws_iam_role.agentless_role.name
+  for_each = aws_iam_role.agentless_role
+
+  role       = each.value.name
   policy_arn = aws_iam_policy.eks_read_policy.arn
 }

--- a/agentless.tf
+++ b/agentless.tf
@@ -5,7 +5,7 @@
 //        --arn arn:aws:iam::${TF_VAR_ACCOUNT_ID}:role/chainguard-agentless \
 //        --group system:masters --username admin
 resource "aws_iam_role" "agentless_role" {
-  for_each = toset(var.enforce_group_ids)
+  for_each = toset(local.enforce_group_ids)
 
   name = "chainguard-agentless"
   assume_role_policy = jsonencode({

--- a/cosigned.tf
+++ b/cosigned.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "cosigned_role" {
-  for_each = toset(var.enforce_group_ids)
+  for_each = toset(local.enforce_group_ids)
 
   name = "chainguard-cosigned-${each.value}"
 

--- a/cosigned.tf
+++ b/cosigned.tf
@@ -26,12 +26,12 @@ resource "aws_iam_role" "cosigned_role" {
 
 // The permissions to grant the "cosigned" role.
 resource "aws_iam_role_policy_attachment" "cosigned_ecr_read" {
-  role       = aws_iam_role.agentless_role.name
+  role       = aws_iam_role.cosigned_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
 }
 
 resource "aws_iam_role_policy_attachment" "cosigned_kms_pki_read" {
-  role = aws_iam_role.agentless_role.name
+  role = aws_iam_role.cosigned_role.name
   // TODO: Is there a better policy for what we need?
   policy_arn = "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
 }

--- a/discovery.tf
+++ b/discovery.tf
@@ -14,7 +14,7 @@ resource "aws_iam_role" "discovery_role" {
           // components, which mints tokens suitable for talking to EKS
           // clusters.  We are authorizing components nested under GROUP
           // to perform this impersonation.
-          "issuer.${var.enforce_domain_name}:sub" : "discovery:${var.enforce_group_id}"
+          "issuer.${var.enforce_domain_name}:sub" : [for id in local.enforce_group_ids : "discovery:${id}"]
           // Tokens must be intended for use with Amazon.
           "issuer.${var.enforce_domain_name}:aud" : "amazon"
         }

--- a/enforce-signer.tf
+++ b/enforce-signer.tf
@@ -17,7 +17,7 @@ resource "aws_iam_role" "enforce_signer_role" {
           // component, which mints tokens suitable for encrypting and decrypting keys.
           // We are authorizing components nested under GROUP to perform this
           // impersonation.
-          "issuer.${var.enforce_domain_name}:sub" : "signer:${var.enforce_group_id}"
+          "issuer.${var.enforce_domain_name}:sub" : [for id in local.enforce_group_ids : "signer:${id}"]
           // Tokens must be intended for use with Amazon.
           "issuer.${var.enforce_domain_name}:aud" : "amazon"
         }

--- a/examples/agentless-eks-cluster/main.tf
+++ b/examples/agentless-eks-cluster/main.tf
@@ -29,7 +29,7 @@ module "account_association" {
 
   aws_account_id      = data.aws_caller_identity.current.account_id
   enforce_domain_name = "chainguard.dev"
-  enforce_group_id    = chainguard_group.root.id
+  enforce_group_ids   = [chainguard_group.root.id]
 }
 
 data "aws_caller_identity" "current" {}
@@ -70,9 +70,9 @@ module "eks" {
   }
 
   manage_aws_auth_configmap = true
-  aws_auth_roles = [
+  aws_auth_roles = [for arn in toset(module.account_association.agentless_role_arn) :
     {
-      rolearn  = module.account_association.agentless_role_arn
+      rolearn  = arn
       username = "admin"
       groups = [
         "system:masters",

--- a/examples/agentless-eks-cluster/main.tf
+++ b/examples/agentless-eks-cluster/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     chainguard = {
       # NB: This provider is currently not public
-      source = "chainguard-dev/chainguard"
+      source = "chainguard/chainguard"
     }
   }
 }
@@ -27,9 +27,8 @@ resource "chainguard_group" "root" {
 module "account_association" {
   source = "./../../"
 
-  aws_account_id      = data.aws_caller_identity.current.account_id
   enforce_domain_name = "chainguard.dev"
-  enforce_group_ids   = [chainguard_group.root.id]
+  enforce_group_id    = chainguard_group.root.id
 }
 
 data "aws_caller_identity" "current" {}
@@ -70,9 +69,9 @@ module "eks" {
   }
 
   manage_aws_auth_configmap = true
-  aws_auth_roles = [for arn in toset(module.account_association.agentless_role_arn) :
+  aws_auth_roles = [
     {
-      rolearn  = arn
+      rolearn  = module.account_association.agentless_role_arn
       username = "admin"
       groups = [
         "system:masters",

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -26,7 +26,7 @@ module "account_association" {
 
   aws_account_id      = data.aws_caller_identity.current.account_id
   enforce_domain_name = "chainguard.dev"
-  enforce_group_id    = chainguard_group.root.id
+  enforce_group_ids   = [chainguard_group.root.id]
 }
 
 data "aws_caller_identity" "current" {}

--- a/examples/multiple-group-ids/main.tf
+++ b/examples/multiple-group-ids/main.tf
@@ -25,7 +25,7 @@ module "account_association" {
   source = "./../../"
 
   enforce_domain_name = "chainguard.dev"
-  enforce_group_id    = chainguard_group.root.id
+  enforce_group_ids   = [chainguard_group.root.id, "0000000000000"]
 }
 
 data "aws_caller_identity" "current" {}

--- a/main.tf
+++ b/main.tf
@@ -16,9 +16,11 @@ resource "aws_iam_openid_connect_provider" "chainguard_idp" {
 }
 
 resource "aws_iam_role" "canary_role" {
+  for_each = toset(var.enforce_group_ids)
+
   // Canary role has no permissions, but is used to validate that AWS account
   // connection has been correctly set up.
-  name = "chainguard-canary"
+  name = "chainguard-canary-${each.value}"
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [{
@@ -33,7 +35,7 @@ resource "aws_iam_role" "canary_role" {
           // component, which mints tokens suitable for testing.  We are
           // authorizing components nested under GROUP to perform this
           // impersonation.
-          "issuer.${var.enforce_domain_name}:sub" : "canary:${var.enforce_group_id}"
+          "issuer.${var.enforce_domain_name}:sub" : "canary:${each.value}"
           // Tokens must be intended for use with Amazon.
           "issuer.${var.enforce_domain_name}:aud" : "amazon"
         }

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+locals {
+  enforce_group_ids = length(var.enforce_group_ids) > 0 ? var.enforce_group_ids : [var.enforce_group_id]
+}
+
 // This configures a Chainguard environment's OIDC issuer as an Identity
 // Provider (IdP), and allows the list of audiences specified via AUDIENCE.
 resource "aws_iam_openid_connect_provider" "chainguard_idp" {
@@ -16,7 +20,7 @@ resource "aws_iam_openid_connect_provider" "chainguard_idp" {
 }
 
 resource "aws_iam_role" "canary_role" {
-  for_each = toset(var.enforce_group_ids)
+  for_each = toset(local.enforce_group_ids)
 
   // Canary role has no permissions, but is used to validate that AWS account
   // connection has been correctly set up.

--- a/main.tf
+++ b/main.tf
@@ -20,11 +20,9 @@ resource "aws_iam_openid_connect_provider" "chainguard_idp" {
 }
 
 resource "aws_iam_role" "canary_role" {
-  for_each = toset(local.enforce_group_ids)
-
   // Canary role has no permissions, but is used to validate that AWS account
   // connection has been correctly set up.
-  name = "chainguard-canary-${each.value}"
+  name = "chainguard-canary"
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [{
@@ -39,7 +37,7 @@ resource "aws_iam_role" "canary_role" {
           // component, which mints tokens suitable for testing.  We are
           // authorizing components nested under GROUP to perform this
           // impersonation.
-          "issuer.${var.enforce_domain_name}:sub" : "canary:${each.value}"
+          "issuer.${var.enforce_domain_name}:sub" : [for id in local.enforce_group_ids : "canary:${id}"]
           // Tokens must be intended for use with Amazon.
           "issuer.${var.enforce_domain_name}:aud" : "amazon"
         }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,7 @@
 output "agentless_role_arn" {
-  value       = aws_iam_role.agentless_role.arn
+  value = {
+    for k, v in aws_iam_role.agentless_role : k => v.arn
+  }
   description = <<-EOF
     This defines a role without permissions in IAM, but which should be authorized
     to manage clusters via:

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,5 @@
 output "agentless_role_arn" {
-  value = {
-    for k, v in aws_iam_role.agentless_role : k => v.arn
-  }
+  value = aws_iam_role.agentless_role.arn
   description = <<-EOF
     This defines a role without permissions in IAM, but which should be authorized
     to manage clusters via:

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "agentless_role_arn" {
-  value = aws_iam_role.agentless_role.arn
+  value       = aws_iam_role.agentless_role.arn
   description = <<-EOF
     This defines a role without permissions in IAM, but which should be authorized
     to manage clusters via:

--- a/variables.tf
+++ b/variables.tf
@@ -6,11 +6,23 @@ variable "enforce_domain_name" {
   nullable    = false
 }
 
-variable "enforce_group_ids" {
-  type        = list(string)
-  description = "Enforce IAM group IDs to bind your AWS account to"
+variable "enforce_group_id" {
+  type        = string
+  description = "DEPRECATED: Please use 'enforce_group_ids'. Enforce IAM group ID to bind your AWS account to"
   sensitive   = false
   nullable    = false
+
+  validation {
+    condition     = length(regexall("^[a-f0-9]{40}(\\/[a-f0-9]{16})*$", var.enforce_group_id)) == 1
+    error_message = "The value 'enforce_group_id' must be a valid group id."
+  }
+}
+
+variable "enforce_group_ids" {
+  type        = list(string)
+  description = "Enforce IAM group IDs to bind your AWS account to. If both 'enforce_group_id' and 'enforce_group_ids' are specified, 'enforce_group_id' is ignored."
+  sensitive   = false
+  default     = []
 
   validation {
     condition     = length(var.enforce_group_ids) > 0

--- a/variables.tf
+++ b/variables.tf
@@ -6,14 +6,18 @@ variable "enforce_domain_name" {
   nullable    = false
 }
 
-variable "enforce_group_id" {
-  type        = string
-  description = "Enforce IAM group ID to bind your AWS account to"
+variable "enforce_group_ids" {
+  type        = list(string)
+  description = "Enforce IAM group IDs to bind your AWS account to"
   sensitive   = false
   nullable    = false
 
   validation {
-    condition     = length(regexall("^[a-f0-9]{40}(\\/[a-f0-9]{16})*$", var.enforce_group_id)) == 1
-    error_message = "enforce_group_id must be a valid group id"
+    condition     = length(var.enforce_group_ids) > 0
+    error_message = "Must provide at least one id to enforce_group_ids."
+  }
+  validation {
+    condition     = can([for g in var.enforce_group_ids : regex("^[a-f0-9]{40}(\\/[a-f0-9]{16})*$", g)])
+    error_message = "IDs in enforce_group_ids must be a valid group id."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,6 @@ variable "enforce_group_id" {
   description = "DEPRECATED: Please use 'enforce_group_ids'. Enforce IAM group ID to bind your AWS account to"
   default     = ""
   sensitive   = false
-  nullable    = false
 
   validation {
     condition     = var.enforce_group_id != "" ? length(regexall("^[a-f0-9]{40}(\\/[a-f0-9]{16})*$", var.enforce_group_id)) == 1 : true
@@ -28,5 +27,14 @@ variable "enforce_group_ids" {
   validation {
     condition     = can([for g in var.enforce_group_ids : regex("^[a-f0-9]{40}(\\/[a-f0-9]{16})*$", g)])
     error_message = "IDs in enforce_group_ids must be a valid group id."
+  }
+}
+
+resource "null_resource" "enforce_group_id_is_specified" {
+  lifecycle {
+    precondition {
+      condition     = length(var.enforce_group_ids) > 0 || var.enforce_group_id != ""
+      error_message = "one of variable [enforce_group_id, enforce_group_ids] must be specified."
+    }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -9,11 +9,12 @@ variable "enforce_domain_name" {
 variable "enforce_group_id" {
   type        = string
   description = "DEPRECATED: Please use 'enforce_group_ids'. Enforce IAM group ID to bind your AWS account to"
+  default     = ""
   sensitive   = false
   nullable    = false
 
   validation {
-    condition     = length(regexall("^[a-f0-9]{40}(\\/[a-f0-9]{16})*$", var.enforce_group_id)) == 1
+    condition     = var.enforce_group_id != "" : length(regexall("^[a-f0-9]{40}(\\/[a-f0-9]{16})*$", var.enforce_group_id)) == 1 : true
     error_message = "The value 'enforce_group_id' must be a valid group id."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,7 @@ variable "enforce_group_id" {
   nullable    = false
 
   validation {
-    condition     = var.enforce_group_id != "" : length(regexall("^[a-f0-9]{40}(\\/[a-f0-9]{16})*$", var.enforce_group_id)) == 1 : true
+    condition     = var.enforce_group_id != "" ? length(regexall("^[a-f0-9]{40}(\\/[a-f0-9]{16})*$", var.enforce_group_id)) == 1 : true
     error_message = "The value 'enforce_group_id' must be a valid group id."
   }
 }
@@ -25,10 +25,6 @@ variable "enforce_group_ids" {
   sensitive   = false
   default     = []
 
-  validation {
-    condition     = length(var.enforce_group_ids) > 0
-    error_message = "Must provide at least one id to enforce_group_ids."
-  }
   validation {
     condition     = can([for g in var.enforce_group_ids : regex("^[a-f0-9]{40}(\\/[a-f0-9]{16})*$", g)])
     error_message = "IDs in enforce_group_ids must be a valid group id."


### PR DESCRIPTION
Rather than only supporting the association of a single enforce group id, support multiple group ids, as a list.

Toward addressing https://github.com/chainguard-dev/customer-issues/issues/66

Signed-off-by: Kenny Leung <kleung@chainguard.dev>