### PR TITLE
fix: typo in examples

### DIFF
--- a/examples/agentless-eks-cluster/main.tf
+++ b/examples/agentless-eks-cluster/main.tf
@@ -34,7 +34,7 @@ module "account_association" {
 
 data "aws_caller_identity" "current" {}
 
-resource "chainguard_account_associations" "demo-chaingaurd-dev-binding" {
+resource "chainguard_account_associations" "demo-chainguard-dev-binding" {
   group = chainguard_group.root.id
   amazon {
     account = data.aws_caller_identity.current.account_id

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -31,7 +31,7 @@ module "account_association" {
 
 data "aws_caller_identity" "current" {}
 
-resource "chainguard_account_associations" "demo-chaingaurd-dev-binding" {
+resource "chainguard_account_associations" "demo-chainguard-dev-binding" {
   group = chainguard_group.root.id
   amazon {
     account = data.aws_caller_identity.current.account_id


### PR DESCRIPTION
Signed-off-by: Hector Fernandez <hector@chainguard.dev>

I found what I believe it was a typo, non intentional in my opinion.