### PR TITLE
Cleanup: Use a dedicated policy for discovery.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_openid_connect_provider.chainguard_idp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
+| [aws_iam_policy.chainguard_discovery_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.eks_read_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.agentless_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.canary_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |

--- a/agentless.tf
+++ b/agentless.tf
@@ -29,7 +29,7 @@ resource "aws_iam_role" "agentless_role" {
   })
 }
 
-// Our agentless/discovery roles need describe/list to look up cluster names from
+// Our agentless role needs describe/list to look up cluster names from
 // the EKS endpoints they are provided.  As our managed agents start up
 // they will look up the cluster-name based on this endpoint, and then
 // use that cluster-name to authenticate with the cluster.

--- a/discovery.tf
+++ b/discovery.tf
@@ -23,8 +23,51 @@ resource "aws_iam_role" "discovery_role" {
   })
 }
 
+// Our discovery role needs to list available regions, and resources within
+// those regions as part of its discovery scanning.  Currently this allows
+// us to discovery EKS and ECS resources.
+resource "aws_iam_policy" "chainguard_discovery_policy" {
+  name        = "chainguard-discovery-policy"
+  description = "A policy to allow Chainguard to list and describe resources."
+  policy      = <<-EOF
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "ec2:DescribeRegions",
+
+                    "eks:ListClusters",
+                    "eks:DescribeCluster",
+
+                    "ecs:ListServicesByNamespace",
+                    "ecs:ListAttributes",
+                    "ecs:ListServices",
+                    "ecs:ListAccountSettings",
+                    "ecs:ListTagsForResource",
+                    "ecs:ListTasks",
+                    "ecs:ListTaskDefinitionFamilies",
+                    "ecs:ListContainerInstances",
+                    "ecs:ListTaskDefinitions",
+                    "ecs:ListClusters",
+                    "ecs:DescribeTaskSets",
+                    "ecs:DescribeTaskDefinition",
+                    "ecs:DescribeClusters",
+                    "ecs:DescribeCapacityProviders",
+                    "ecs:DescribeServices",
+                    "ecs:DescribeContainerInstances",
+                    "ecs:DescribeTasks"
+                ],
+                "Resource": "*"
+            }
+        ]
+    }
+  EOF
+}
+
 // The permissions to grant the "discovery" role.
 resource "aws_iam_role_policy_attachment" "discovery_cluster_viewer" {
   role       = aws_iam_role.discovery_role.name
-  policy_arn = aws_iam_policy.eks_read_policy.arn
+  policy_arn = aws_iam_policy.chainguard_discovery_policy.arn
 }


### PR DESCRIPTION
:broom: This changes discovery to use its own custom policy, since it needs to be able to DescribeRegions.  While I'm at it, I am adding the permissions to discover ECS resources, which is on our roadmap as well.

/kind cleanup