### PR TITLE
create enforce_signer role and grant encrypt/decrypt perms

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,13 @@ No modules.
 | [aws_iam_role.canary_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.cosigned_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.discovery_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.enforce_signer_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.agentless_eks_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cosigned_ecr_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cosigned_kms_pki_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.discovery_cluster_viewer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.enforce_signer_kms_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 

--- a/enforce-signer.tf
+++ b/enforce-signer.tf
@@ -1,0 +1,38 @@
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_role" "enforce_signer_role" {
+  name = "chainguard-enforce-signer"
+
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [{
+      "Effect" : "Allow",
+      "Principal" : {
+        "Federated" : aws_iam_openid_connect_provider.chainguard_idp.arn
+      },
+      "Action" : [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*"
+      ],
+      "Resource" : "*",
+      "Condition" : {
+        "StringEquals" : {
+          // This role may only be impersonated by Chainguard's "enforce-signer"
+          // component, which mints tokens suitable for encrypting and decrypting keys.
+          // We are authorizing components nested under GROUP to perform this
+          // impersonation.
+          "issuer.${var.enforce_domain_name}:sub" : "signer:${var.enforce_group_id}"
+          // Tokens must be intended for use with Amazon.
+          "issuer.${var.enforce_domain_name}:aud" : "amazon"
+        }
+      }
+    }]
+  })
+}
+
+// The permissions to grant the "enforce_signer" role.
+resource "aws_iam_role_policy_attachment" "enforce_signer_kms_keys" {
+  role       = aws_iam_role.enforce_signer_role.name
+  policy_arn = "arn:aws:kms:*:${data.aws_caller_identity.current.account_id}:key/*"
+}


### PR DESCRIPTION
Signed-off-by: Hector Fernandez <hector@chainguard.dev>

related to: https://github.com/chainguard-dev/mono/issues/6552

Create enforce_signer role and grant encrypt/decrypt permissions. 
