### PR TITLE
fix policy for signer role

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ No modules.
 | [aws_iam_openid_connect_provider.chainguard_idp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
 | [aws_iam_policy.chainguard_discovery_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.eks_read_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.enforce_signer_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.agentless_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.canary_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.cosigned_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |

--- a/enforce-signer.tf
+++ b/enforce-signer.tf
@@ -10,12 +10,7 @@ resource "aws_iam_role" "enforce_signer_role" {
       "Principal" : {
         "Federated" : aws_iam_openid_connect_provider.chainguard_idp.arn
       },
-      "Action" : [
-        "kms:Encrypt",
-        "kms:Decrypt",
-        "kms:ReEncrypt*"
-      ],
-      "Resource" : "*",
+      "Action" : "sts:AssumeRoleWithWebIdentity",
       "Condition" : {
         "StringEquals" : {
           // This role may only be impersonated by Chainguard's "enforce-signer"
@@ -31,8 +26,32 @@ resource "aws_iam_role" "enforce_signer_role" {
   })
 }
 
+// Our enforce signer role needs encrypt/decrypt/re-encrypt with KMS.
+// This policy is based on this sample:
+// https://docs.aws.amazon.com/eks/latest/userguide/security_iam_id-based-policy-examples.html#policy_example2
+resource "aws_iam_policy" "enforce_signer_policy" {
+  name        = "chainguard-signer-policy"
+  description = "A policy to allow Chainguard to Encrypt|Decrypt|Reencrypt using KMS."
+  policy      = <<-EOF
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "kms:Encrypt",
+            "kms:Decrypt",
+            "kms:ReEncrypt*"
+          ],
+          "Resource": "*"
+        }
+      ]
+    }
+  EOF
+}
+
 // The permissions to grant the "enforce_signer" role.
 resource "aws_iam_role_policy_attachment" "enforce_signer_kms_keys" {
   role       = aws_iam_role.enforce_signer_role.name
-  policy_arn = "arn:aws:kms:*:${data.aws_caller_identity.current.account_id}:key/*"
+  policy_arn = aws_iam_policy.enforce_signer_policy.arn
 }


### PR DESCRIPTION
This fixes the following error

```
│ Error: failed creating IAM Role (chainguard-enforce-signer): MalformedPolicyDocument: Has prohibited field Resource
│ 	status code: 400, request id: be979139-f596-409d-a8ae-bea1fcdb3270
│ 
│   with module.account_association.aws_iam_role.enforce_signer_role,
│   on ../../terraform-aws-chainguard-account-association/enforce-signer.tf line 3, in resource "aws_iam_role" "enforce_signer_role":
│    3: resource "aws_iam_role" "enforce_signer_role" {
```
As explained here, https://stackoverflow.com/questions/70656138/malformed-policy-document-has-prohibited-field-resource, there are two different policies at play and it can't be combined.

This mirrors what we do in agentless.tf as well https://github.com/chainguard-dev/terraform-aws-chainguard-account-association/blob/main/agentless.tf#L38


Signed-off-by: Kenny Leung <kleung@chainguard.dev>