### PR TITLE
Feature: Enable discovery to leverage audit logs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,17 @@ resource "chainguard_account_associations" "example" {
 To configured the connection on AWS side use this module as follows:
 
 ```Terraform
-
-
-module "chainguard-account-association" {
+module "aws-impersonation" {
   source = "chainguard-dev/chainguard-account-association/aws"
 
   enforce_group_id  = "<< enforce group id >>"
   enforce_group_ids = ["<< enforce group id 1 >>", "<< enforce group id 2 >>"] # Optional, used only when more than one group
+}
+
+// While the above is global configuration, this module must be invoked for each
+// AWS region containing resources to be monitored by Enforce.
+module "aws-auditlogs" {
+  source = "chainguard-dev/chainguard-account-association/aws/auditlogs"
 }
 ```
 

--- a/agentless.tf
+++ b/agentless.tf
@@ -38,21 +38,19 @@ resource "aws_iam_role" "agentless_role" {
 resource "aws_iam_policy" "eks_read_policy" {
   name        = "chainguard-eks-read-policy"
   description = "A policy to allow Chainguard to list and describe EKS clusters."
-  policy      = <<-EOF
-    {
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Effect": "Allow",
-          "Action": [
-            "eks:DescribeCluster",
-            "eks:ListClusters"
-          ],
-          "Resource": "*"
-        }
-      ]
-    }
-  EOF
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "eks:DescribeCluster",
+          "eks:ListClusters"
+        ],
+        "Resource" : "*"
+      }
+    ]
+  })
 }
 
 // The permissions to grant the "agentless" role.

--- a/auditlogs/main.tf
+++ b/auditlogs/main.tf
@@ -1,0 +1,75 @@
+// Configure the SNS topic to which Chainguard will subscribe for
+// audit logging events.
+resource "aws_sns_topic" "chainguard_auditlogs" {
+  name = "chainguard-auditlogs"
+}
+
+// This configures CloudWatch to monitor events coming from ECS
+resource "aws_cloudwatch_event_rule" "ecs" {
+  name        = "chainguard-ecs-auditlogs"
+  description = "Capture ECS events that Chainguard Enforce needs to monitor"
+
+  event_pattern = jsonencode({
+    "source" : [
+      "aws.ecs"
+    ],
+    "detail-type" : [
+      "ECS Task State Change",
+      "ECS Container Instance State Change",
+      "ECS Deployment State Change"
+    ]
+  })
+}
+resource "aws_cloudwatch_event_target" "ecs" {
+  rule = aws_cloudwatch_event_rule.ecs.name
+  arn  = aws_sns_topic.chainguard_auditlogs.arn
+}
+
+// This configures CloudWatch to monitor events coming from AppRunner
+resource "aws_cloudwatch_event_rule" "apprunner" {
+  name        = "chainguard-apprunner-auditlogs"
+  description = "Capture AppRunner events that Chainguard Enforce needs to monitor"
+
+  event_pattern = jsonencode({
+    "source" : [
+      "aws.apprunner"
+    ],
+    "detail-type" : [
+      "AppRunner Service Status Change",
+      "AppRunner Service Operation Status Change"
+    ]
+  })
+}
+resource "aws_cloudwatch_event_target" "apprunner" {
+  rule = aws_cloudwatch_event_rule.apprunner.name
+  arn  = aws_sns_topic.chainguard_auditlogs.arn
+}
+
+// Allow any CloudWatch event rules configured above to publish to the
+// auditlog SNS topic.
+resource "aws_sns_topic_policy" "chainguard_auditlogs" {
+  arn = aws_sns_topic.chainguard_auditlogs.arn
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Id" : "snspolicy",
+    "Statement" : [
+      {
+        "Sid" : "First",
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "events.amazonaws.com"
+        },
+        "Action" : "sns:Publish",
+        "Resource" : aws_sns_topic.chainguard_auditlogs.arn,
+        "Condition" : {
+          "ArnEquals" : {
+            "aws:SourceArn" : [
+              aws_cloudwatch_event_rule.ecs.arn,
+              aws_cloudwatch_event_rule.apprunner.arn,
+            ]
+          }
+        }
+      }
+    ]
+  })
+}

--- a/discovery.tf
+++ b/discovery.tf
@@ -28,42 +28,76 @@ resource "aws_iam_role" "discovery_role" {
 // us to discovery EKS and ECS resources.
 resource "aws_iam_policy" "chainguard_discovery_policy" {
   name        = "chainguard-discovery-policy"
-  description = "A policy to allow Chainguard to list and describe resources."
-  policy      = <<-EOF
-    {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "ec2:DescribeRegions",
+  description = "A policy to allow Chainguard to enumerate resources, and manage audit log subscriptions."
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          // Enumerate regions as part of discovery.
+          "ec2:DescribeRegions",
 
-                    "eks:ListClusters",
-                    "eks:DescribeCluster",
+          // List clusters and get enregistration details.
+          "eks:ListClusters",
+          "eks:DescribeCluster",
 
-                    "ecs:ListServicesByNamespace",
-                    "ecs:ListAttributes",
-                    "ecs:ListServices",
-                    "ecs:ListAccountSettings",
-                    "ecs:ListTagsForResource",
-                    "ecs:ListTasks",
-                    "ecs:ListTaskDefinitionFamilies",
-                    "ecs:ListContainerInstances",
-                    "ecs:ListTaskDefinitions",
-                    "ecs:ListClusters",
-                    "ecs:DescribeTaskSets",
-                    "ecs:DescribeTaskDefinition",
-                    "ecs:DescribeClusters",
-                    "ecs:DescribeCapacityProviders",
-                    "ecs:DescribeServices",
-                    "ecs:DescribeContainerInstances",
-                    "ecs:DescribeTasks"
-                ],
-                "Resource": "*"
-            }
-        ]
-    }
-  EOF
+          // Read ECS resource metadata for discovery.
+          "ecs:ListServicesByNamespace",
+          "ecs:ListAttributes",
+          "ecs:ListServices",
+          "ecs:ListAccountSettings",
+          "ecs:ListTagsForResource",
+          "ecs:ListTasks",
+          "ecs:ListTaskDefinitionFamilies",
+          "ecs:ListContainerInstances",
+          "ecs:ListTaskDefinitions",
+          "ecs:ListClusters",
+          "ecs:DescribeTaskSets",
+          "ecs:DescribeTaskDefinition",
+          "ecs:DescribeClusters",
+          "ecs:DescribeCapacityProviders",
+          "ecs:DescribeServices",
+          "ecs:DescribeContainerInstances",
+          "ecs:DescribeTasks",
+
+          // Read AppRunner resource metadata for discovery.
+          "apprunner:List*",
+          "apprunner:Describe*",
+
+          // Used to check existence of auditlog queues.
+          "sqs:GetQueueUrl",
+
+          // Used to set up queues when clusters register.
+          "sqs:CreateQueue",
+          "sqs:TagQueue",
+
+          // Used to receive and cleanup messages.
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+
+          // Used to clean things up when clusters unregister.
+          "sqs:DeleteQueue",
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          // Used to [un]subscribe SQS queues to the regional SNS topics
+          // containing audit logs where we are managing AWS resources.
+          "sns:Subscribe",
+          "sns:Unsubscribe",
+          // Used to check existence of subscriptions.
+          "sns:ListSubscriptionsByTopic"
+        ],
+        // Discovery manages subscriptions to auditlog topics in this account.
+        // These are created via the "auditlog" submodule, which must be instantiated
+        // for each region where the user has resources they want us to discover.
+        "Resource" : "arn:aws:sns:*:${data.aws_caller_identity.current.account_id}:chainguard-auditlogs"
+      }
+    ]
+  })
 }
 
 // The permissions to grant the "discovery" role.

--- a/enforce-signer.tf
+++ b/enforce-signer.tf
@@ -1,5 +1,3 @@
-data "aws_caller_identity" "current" {}
-
 resource "aws_iam_role" "enforce_signer_role" {
   name = "chainguard-enforce-signer"
 
@@ -30,22 +28,20 @@ resource "aws_iam_role" "enforce_signer_role" {
 resource "aws_iam_policy" "enforce_signer_policy" {
   name        = "chainguard-signer-policy"
   description = "A policy to allow Chainguard to sign and verify using KMS."
-  policy      = <<-EOF
-    {
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Effect": "Allow",
-          "Action": [
-            "kms:Sign",
-            "kms:GetPublicKey",
-            "kms:DescribeKey"
-          ],
-          "Resource": "*"
-        }
-      ]
-    }
-  EOF
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "kms:Sign",
+          "kms:GetPublicKey",
+          "kms:DescribeKey"
+        ],
+        "Resource" : "*"
+      }
+    ]
+  })
 }
 
 // The permissions to grant the "enforce_signer" role.

--- a/examples/agentless-eks-cluster/main.tf
+++ b/examples/agentless-eks-cluster/main.tf
@@ -14,7 +14,7 @@ terraform {
 }
 
 provider "chainguard" {
-  console_api = "https://console-api.chainguard.dev"
+  console_api = "https://console-api.enforce.dev"
 }
 
 provider "aws" {}
@@ -24,11 +24,15 @@ resource "chainguard_group" "root" {
   description = "root group for demo"
 }
 
-module "account_association" {
+module "aws-impersonation" {
   source = "./../../"
 
-  enforce_domain_name = "chainguard.dev"
+  enforce_domain_name = "enforce.dev"
   enforce_group_id    = chainguard_group.root.id
+}
+
+module "aws-auditlogs" {
+  source = "./../../auditlogs"
 }
 
 data "aws_caller_identity" "current" {}

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -11,7 +11,7 @@ terraform {
 }
 
 provider "chainguard" {
-  console_api = "https://console-api.chainguard.dev"
+  console_api = "https://console-api.enforce.dev"
 }
 
 provider "aws" {}
@@ -21,11 +21,15 @@ resource "chainguard_group" "root" {
   description = "root group for demo"
 }
 
-module "account_association" {
+module "aws-impersonation" {
   source = "./../../"
 
-  enforce_domain_name = "chainguard.dev"
+  enforce_domain_name = "enforce.dev"
   enforce_group_id    = chainguard_group.root.id
+}
+
+module "aws-auditlogs" {
+  source = "./../../auditlogs"
 }
 
 data "aws_caller_identity" "current" {}

--- a/examples/multiple-group-ids/main.tf
+++ b/examples/multiple-group-ids/main.tf
@@ -11,7 +11,7 @@ terraform {
 }
 
 provider "chainguard" {
-  console_api = "https://console-api.chainguard.dev"
+  console_api = "https://console-api.enforce.dev"
 }
 
 provider "aws" {}
@@ -21,11 +21,15 @@ resource "chainguard_group" "root" {
   description = "root group for demo"
 }
 
-module "account_association" {
+module "aws-impersonation" {
   source = "./../../"
 
-  enforce_domain_name = "chainguard.dev"
+  enforce_domain_name = "enforce.dev"
   enforce_group_ids   = [chainguard_group.root.id, "0000000000000"]
+}
+
+module "aws-auditlogs" {
+  source = "./../../auditlogs"
 }
 
 data "aws_caller_identity" "current" {}

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 locals {
   enforce_group_ids = length(var.enforce_group_ids) > 0 ? var.enforce_group_ids : [var.enforce_group_id]
 }
@@ -12,9 +14,9 @@ resource "aws_iam_openid_connect_provider" "chainguard_idp" {
   # This is not easily scripted, so hard-coding this seems preferable.  Follow
   # the AWS documentation for producing thumbprint if this does not work.
   thumbprint_list = [
-    # ISRG root certificate (LetsEncrypt) 
+    # ISRG root certificate (LetsEncrypt)
     "933c6ddee95c9c41a40f9f50493d82be03ad87bf",
-    # GlobalSign root certificate (Google Managed Certficates) 
+    # GlobalSign root certificate (Google Managed Certficates)
     "08745487e891c19e3078c1f2a07e452950ef36f6"
   ]
 }


### PR DESCRIPTION
:gift: This change enables Chainguard Enforce's discovery mechanism to leverage CloudWatch audit log events published to an SNS topic to direct Enforce to immediately reconcile any changes to monitored resources.

The user will need to instantiate the new `auditlog` sub-module to create topics in each region they would like Enforce to monitor.

/kind feature