### PR TITLE
Fix: Add a slash to the import path for regional things.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ module "aws-impersonation" {
   enforce_group_ids = ["<< enforce group id 1 >>", "<< enforce group id 2 >>"] # Optional, used only when more than one group
 }
 
-// While the above is global configuration, this module must be invoked for each
-// AWS region containing resources to be monitored by Enforce.
+# While the above is global configuration, this module must be invoked for each
+# AWS region containing resources to be monitored by Enforce.
 module "aws-auditlogs" {
-  source = "chainguard-dev/chainguard-account-association/aws/auditlogs"
+  # The // here tells terraform that auditlogs is a directory in the repo.
+  source = "chainguard-dev/chainguard-account-association/aws//auditlogs"
 }
 ```
 


### PR DESCRIPTION
:bug: This adds a missing slash that terraform needs to distinguish the directory from the module path.

/kind bug