### PR TITLE
fix(ci): GitHub Actions security hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# See GitHub's documentation for more information on this file:
+# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 3
+  - package-ecosystem: "terraform"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 3

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,6 +14,8 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        persist-credentials: false
     - name: Render terraform docs and fail on diff
       uses: step-security/terraform-docs-action@43f977ff483b4dcf2d1c13fce93bfc30b1164bd9 # v1.4.4
       with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,9 +3,13 @@ name: Generate terraform docs
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Clone the repository
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # 3.0.0
+      uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
     - name: Lint
       run: |
         terraform fmt -check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,8 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        persist-credentials: false
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # 3.0.0
     - name: Lint

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,13 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/zizmor.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/zizmor.yml'
 
 permissions: {}
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,8 @@
+rules:
+  # Cosmetic pedantic-only findings — suppressed across the campaign.
+  anonymous-definition:
+    disable: true
+  undocumented-permissions:
+    disable: true
+  concurrency-limits:
+    disable: true

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,4 +1,7 @@
 rules:
+  dependabot-cooldown:
+    config:
+      days: 3
   # Cosmetic pedantic-only findings — suppressed across the campaign.
   anonymous-definition:
     disable: true


### PR DESCRIPTION
This PR applies a set of GitHub Actions hardening fixes to the workflows in
`.github/workflows/`, surfaced by static analysis (zizmor / actionlint).

## What this changes

- **`persist-credentials: false` on checkout steps** (`documentation.yml`,
  `main.yml`). Neither job pushes back to the repo, so the auto-persisted
  `GITHUB_TOKEN` is unnecessary; leaving it in the local git config widens the
  blast radius of any later step. Explicitly opting out drops the credential
  from `.git/config`.
- **Least-privilege permissions on the docs workflow** (`documentation.yml`).
  Adds a top-level `permissions: {}` (deny-all default) and grants the `docs`
  job only `contents: read`, which is all it needs to clone and render docs.
- **Corrected version comment on `hashicorp/setup-terraform`** (`main.yml`).
  The pinned SHA's trailing comment read `# 3.0.0`; aligned it to the tag form
  `# v3.0.0` so the pin and its human-readable annotation agree.
- **Repo-level zizmor config** (`.github/zizmor.yml`). Adds a small config that
  disables three pedantic, cosmetic-only rules (`anonymous-definition`,
  `undocumented-permissions`, `concurrency-limits`) so future scans stay focused
  on substantive findings. The existing `zizmor.yaml` workflow's `paths:` trigger
  is extended to include this new file so config changes re-run the scan.
- **Dependabot coverage** (`.github/dependabot.yml`). The workflows pin every
  external action to a commit SHA, but the repo had no dependabot config, so the
  pins had no automated freshness mechanism and were being bumped by hand. Adds
  weekly `github-actions` and `terraform` update coverage with a 3-day cooldown.
  The matching `dependabot-cooldown` threshold is declared in `.github/zizmor.yml`.

## Test plan

- `zizmor .github/` — clean after these changes (the cosmetic rules above are
  suppressed via the committed config).
- `actionlint` — workflows still parse with no errors.
- `terraform fmt -check` / validate behavior is unchanged (only checkout and
  permissions metadata were touched, not the lint steps).

An independent review of the change set found no blocking issues.

Refs: PSEC-923